### PR TITLE
Use Ubuntu 18.04 instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
 
 # Install dependencies
 RUN apt-get -y -q update         \


### PR DESCRIPTION
For `binutils=2.30` ref https://unix.stackexchange.com/questions/513921/how-to-get-around-r-x86-64-plt32-error-when-bisecting-the-linux-kernel and the `Unsupported relocation type: R_X86_64_PLT32` error